### PR TITLE
Optimizations, corrections, cleanup, debug enhancements and feature extensions

### DIFF
--- a/apx/apx_unit.pro
+++ b/apx/apx_unit.pro
@@ -68,7 +68,7 @@ INCLUDEPATH += \
     $$PWD/test
 
 DEFINES += \
-    UNIT_TEST\
+    APX_UNIT_TEST\
 
 include(../remotefile/remotefile.pri)
 include(../util/util.pri)

--- a/apx/inc/qapx_client.h
+++ b/apx/inc/qapx_client.h
@@ -18,28 +18,29 @@ namespace Apx
    {
       Q_OBJECT
    public:
-      Client(QObject *parent=NULL);
+      Client(QObject *parent=NULL, bool inPortNotifyWithName=true);
       virtual ~Client();
 
       void createLocalNode(const char *apxText);
-      void createLocalNode(QString &apxText);
-      void connectTcp(QHostAddress address,quint16 port);
+      void createLocalNode(const QString &apxText);
+      void connectTcp(const QHostAddress& address,quint16 port);
       void close();
 
       //NodeHandler API
-      void inPortDataNotification(NodeData *nodeData, QApxSimplePort *port, QVariant &value);
+      void inPortDataNotification(NodeData *nodeData, QApxSimplePort *port, const QVariant &value);
 
       //client user API
       Q_DECL_DEPRECATED void setProvidePort(int portId, QVariant &value);
       void setProvidePortValue(int portId, QVariant &value);
-      int findProvidePortId(QString &name);
-      int findProvidePortId(const char *name);
-      int findRequirePortId(QString &name);
-      int findRequirePortId(const char *name);
+      int findProvidePortId(const QString &name) const;
+      int findProvidePortId(const char* const name) const;
+      int findRequirePortId(const QString &name) const;
+      int findRequirePortId(const char* const name) const;
 
       Apx::NodeData *getNodeData() {return &mNodeData;}
 
    protected:
+      bool mInPortNotifyWithName;
       NodeData mNodeData;
       Apx::FileMap mLocalFileMap;
       Apx::FileMap mRemoteFileMap;
@@ -51,11 +52,15 @@ namespace Apx
 private slots:
       void onConnected();
       void onDisconnected();
+      void onRemoteFileFullWrite(const QString& fileName);
 
   signals:
-      void requirePortData(int portId, QString &portName, QVariant &value);
+      void requirePortData(int portId, const QString &portName, const QVariant &value);
+      void requirePortDataIdOnly(int portId, const QVariant &value);
       void connected();
       void disconnected();
+      // Emitted when all ports have been updated in one message
+      void requirePortsFullyRefreshed();
    };
 }
 

--- a/apx/inc/qapx_compiler.h
+++ b/apx/inc/qapx_compiler.h
@@ -1,7 +1,6 @@
 #ifndef QAPX_COMPILER_H
 #define QAPX_COMPILER_H
 
-#include <QVariant>
 #include <QStack>
 #include <QtGlobal>
 #include <QByteArray>

--- a/apx/inc/qapx_file.h
+++ b/apx/inc/qapx_file.h
@@ -19,7 +19,10 @@ namespace Apx
     */
    class File : public RemoteFile::File
    {
-   public:      
+   public:
+      static const QString cDefinitionSuffix;
+      static const QString cInSuffix;
+      static const QString cOutSuffix;
       File(QString name, quint32 length);
       virtual ~File();
       QByteArray &getFileData(){return mData;}

--- a/apx/inc/qapx_node.h
+++ b/apx/inc/qapx_node.h
@@ -18,13 +18,13 @@ namespace Apx
       QApxDataType *getTypeById(int i);
       void appendRequirePort(QApxSimpleRequirePort *port);
       void appendProvidePort(QApxSimpleProvidePort *port);
-      QApxSimplePort *getRequirePortById(int i);
-      QApxSimplePort *getProvidePortById(int i);
-      int getNumRequirePorts(){return mRequirePorts.size();}
-      int getNumProvidePorts(){return mProvidePorts.size();}
-      QApxSimplePort *findPortByName(const char *name);
+      QApxSimplePort *getRequirePortById(int i) const;
+      QApxSimplePort *getProvidePortById(int i) const;
+      int getNumRequirePorts() const {return mRequirePorts.size();}
+      int getNumProvidePorts() const {return mProvidePorts.size();}
+      QApxSimplePort *findPortByName(const char *name) const;
       void setName(const QString &name);
-      QString &getName();
+      const QString &getName() const;
 
    protected:
       QString mName;
@@ -32,9 +32,9 @@ namespace Apx
       QList<QApxSimplePort*> mRequirePorts;
       QList<QApxSimplePort*> mProvidePorts;
       QMap<QString,QApxSimplePort*> mPortMap;
-      typedef QList<QApxSimplePort*>::iterator PortListIterator;
-      typedef QList<QApxDataType*>::iterator DataTypeListIterator;
-      typedef QMap<QString,QApxSimplePort*>::iterator PortMapItertator;
+      typedef QList<QApxSimplePort*>::const_iterator PortListIterator;
+      typedef QList<QApxDataType*>::const_iterator DataTypeListIterator;
+      typedef QMap<QString,QApxSimplePort*>::const_iterator PortMapItertator;
    };
 }
 #endif //QAPX_NODE_H

--- a/apx/inc/qapx_nodedata.h
+++ b/apx/inc/qapx_nodedata.h
@@ -30,9 +30,9 @@ namespace Apx
 
    struct PackUnpackProg
    {
-      VariantType vtype; //what QVariant it expects
-      QByteArray  prog; //byte code program
-      PackUnpackProg(QApxDataElement *pElement, QByteArray _prog);
+      VariantType vtype;  //what QVariant it expects
+      QByteArray  prog;   //byte code program
+      PackUnpackProg(QApxDataElement *pElement, const QByteArray& _prog);
    };
 
    /**
@@ -51,7 +51,7 @@ namespace Apx
    class NodeHandler
    {
    public:
-      virtual void inPortDataNotification(NodeData *nodeData, QApxSimplePort *port, QVariant &value) = 0;
+      virtual void inPortDataNotification(NodeData *nodeData, QApxSimplePort *port, const QVariant &value) = 0;
    };
 
 
@@ -79,8 +79,8 @@ namespace Apx
       //NodeData API
       Apx::Node* load(const char *apxText);
       Apx::Node* load(QString &apxText);
-      int findProvidePortId(const char *name) const;
-      int findRequirePortId(const char *name) const;
+      int findProvidePortId(const char* const name) const;
+      int findRequirePortId(const char* const name) const;
       bool setProvidePortValue(int portId, QVariant &value);
       bool getRequirePortValue(const QApxSimplePort *port, QVariant &value);
       bool getRequirePortValue(int portIndex, QVariant &value);
@@ -106,7 +106,7 @@ namespace Apx
       void cleanup();
       void populatePortDataMap();
       void writeProvidePortRaw(int portId,const char *pSrc, int length);
-#ifdef UNIT_TEST
+#ifdef APX_UNIT_TEST
    public:
 #else
    protected:

--- a/apx/inc/qapx_stream.h
+++ b/apx/inc/qapx_stream.h
@@ -78,11 +78,11 @@ public:
    void setInputHandler(QApxIStreamEventHandler *handler){mEventHandler = handler;}
    void open();
    void close();
-   bool isOpen(){return mIsOpen;}
-   int getLastMsgType(){return mLastMsgType;}
+   bool isOpen() const {return mIsOpen;}
+   int getLastMsgType() const {return mLastMsgType;}
    void parseBuffer();
-   void write(QByteArray &chunk);
-   int getException(){return mException;}
+   void write(const QByteArray &chunk);
+   int getException() const {return mException;}
 
 protected:
    void reset();

--- a/apx/inc/qapxdatatype.h
+++ b/apx/inc/qapxdatatype.h
@@ -8,9 +8,9 @@ class QApxDataType
 public:
    QApxDataType(const char *name, const char *dsg, const char *attr);
    ~QApxDataType();
-   const char* getName() {return mName;}
-   const char* getDataSignature() {return mDsg;}
-   const char* getAttr() {return mAttr;}
+   const char* getName() const {return mName;}
+   const char* getDataSignature() const {return mDsg;}
+   const char* getAttr() const {return mAttr;}
 protected:
    char *mName;
    char *mDsg;

--- a/apx/inc/qapxsimpleport.h
+++ b/apx/inc/qapxsimpleport.h
@@ -6,16 +6,18 @@ class QApxSimplePort
 public:
    QApxSimplePort(const char *name, const char *dsg, const char *attr);
    virtual ~QApxSimplePort();
-   const char *getName(){return mName;}
-   const char *getDataSignature(){return mDsg;}
-   const char *getAttr(){return mAttr;}
-   virtual bool isRequire() = 0;
+   const char *getName() const {return mName;}
+   const char *getDataSignature() const {return mDsg;}
+   const char *getAttrInitValueAsRaw() const {return mAttrInit;}
+   const char *getAttr() const {return mAttrFull;}
+   virtual bool isRequire() const = 0;
    int getPortIndex() const {return mPortIndex;}
    void setPortIndex(int value){mPortIndex=value;}
 protected:
-   char *mName; //strong reference to name
-   char *mDsg; //strong reference to data signature
-   char *mAttr; //strong reference to port attribute string
+   const char *mName; //strong reference to name
+   const char *mDsg; //strong reference to data signature
+   const char *mAttrFull; //strong reference to full port attribute string
+   const char *mAttrInit; //strong reference to init part of port attribute string
    int mPortIndex;
 };
 
@@ -23,14 +25,14 @@ class QApxSimpleRequirePort : public QApxSimplePort
 {
 public:
    QApxSimpleRequirePort(const char *name, const char *dsg, const char *attr);
-   bool isRequire(){return true;}
+   bool isRequire() const {return true;}
 };
 
 class QApxSimpleProvidePort : public QApxSimplePort
 {
 public:
    QApxSimpleProvidePort(const char *name, const char *dsg, const char *attr);
-   bool isRequire(){return false;}
+   bool isRequire() const {return false;}
 };
 
 

--- a/apx/src/qapx_compiler.cpp
+++ b/apx/src/qapx_compiler.cpp
@@ -1,8 +1,5 @@
 #include "qapx_compiler.h"
-#include <QDebug>
 #include <limits>
-
-#include <QVariant>
 
 #define MAX_PACK_LEN 16777215 //should be equal to 2^24-1
 
@@ -60,7 +57,7 @@ int DataCompiler::genUnpackData(QByteArray &prog, const QApxDataElement *pElemen
          int end = pElement->pElementList->length();
          for (int i=0;i<end;i++)
          {
-            const QApxDataElement *pChildElement = const_cast<QApxDataElement*>(pElement->pElementList->value(i));
+            const QApxDataElement* const& pChildElement = pElement->pElementList->at(i);
             Q_ASSERT(pChildElement != 0);
             recordSelect(prog,pChildElement->name.constData());
             if (pChildElement->baseType == QAPX_BASE_TYPE_RECORD)
@@ -145,7 +142,7 @@ int DataCompiler::genPackData(QByteArray &prog, const QApxDataElement *pElement,
          int end = pElement->pElementList->length();
          for (int i=0;i<end;i++)
          {
-            const QApxDataElement *pChildElement = const_cast<QApxDataElement*>(pElement->pElementList->value(i));
+            const QApxDataElement* const& pChildElement = pElement->pElementList->at(i);
             Q_ASSERT(pChildElement != 0);
             recordSelect(prog,pChildElement->name.constData());
             if (pChildElement->baseType == QAPX_BASE_TYPE_RECORD)

--- a/apx/src/qapx_datavm.cpp
+++ b/apx/src/qapx_datavm.cpp
@@ -1,6 +1,7 @@
 #include "qapx_datavm.h"
 #include "qapx_vmbase.h"
 #include <QtEndian>
+#include <QDebug>
 
 namespace Apx
 {
@@ -108,11 +109,10 @@ int DataVM::execProg(const QByteArray &prog)
    while(pNext<pEnd)
    {
       int opCode;
-      const char *pMark=pNext;
+      const char* const pMark=pNext;
       pNext=parseOpCode(pNext,pEnd,opCode);
       if (pNext>pMark)
       {
-         pMark=pNext;
          pNext = execOperation(opCode,pNext,pEnd,exception);
          if ( exception != VM_EXCEPTION_NO_EXCEPTION )
          {
@@ -460,7 +460,8 @@ int DataVM::execArgs(int progType, int typeId, int packLen)
             }
             else
             {
-               if (mRawData->length() < packLen)
+               const int rawDataLen = mRawData->length();
+               if (rawDataLen < packLen)
                {
                   exception = VM_EXCEPTION_DATA_LEN_TOO_SHORT;
                }
@@ -468,7 +469,7 @@ int DataVM::execArgs(int progType, int typeId, int packLen)
                {
                   //3. setup the data parse pointers and VM Mode
                   mReadBegin=mRawData->constData();
-                  mReadEnd=mReadBegin+mRawData->length();
+                  mReadEnd=mReadBegin+rawDataLen;
                   mReadNext=mReadBegin;
                   mMode = PROG_TYPE_UNPACK;
                }
@@ -479,7 +480,7 @@ int DataVM::execArgs(int progType, int typeId, int packLen)
             //2b. setup the data parse pointers and VM Mode
             mRawData->resize(packLen);
             mWriteNext=(quint8*) mRawData->data();
-            mWriteEnd=(quint8*) mWriteNext+mRawData->length();
+            mWriteEnd=(quint8*) mWriteNext+packLen;
             Q_ASSERT(mRawData->length()==packLen);
             mMode = PROG_TYPE_PACK;
          }

--- a/apx/src/qapx_file.cpp
+++ b/apx/src/qapx_file.cpp
@@ -1,16 +1,20 @@
 #include <QtGlobal>
-#include <QDebug>
 #include <cstring>
 #include "qapx_file.h"
 #include "qapx_nodedata.h"
 
 using namespace std;
 
-Apx::File::File(QString name, quint32 length):RemoteFile::File(name,length),mNodeDataHandler(NULL)
+const QString Apx::File::cDefinitionSuffix = QStringLiteral(".apx");
+const QString Apx::File::cInSuffix = QStringLiteral(".in");
+const QString Apx::File::cOutSuffix = QStringLiteral(".out");
+
+Apx::File::File(QString name, quint32 length)
+    : RemoteFile::File(name,length)
+    , mData((int)length, '\0')
+    , mDataLock()
+    , mNodeDataHandler(NULL)
 {
-   mData.resize((int)length);
-   Q_ASSERT(mData.length() == (int)length);
-   memset(mData.data(),0, length);
 }
 
 Apx::File::~File()

--- a/apx/src/qapx_filemap.cpp
+++ b/apx/src/qapx_filemap.cpp
@@ -7,11 +7,11 @@
  */
 bool Apx::FileMap::assignFileAddressDefault(RemoteFile::File *file)
 {
-   if (file->mName.endsWith(".in") || file->mName.endsWith(".out") )
+   if (file->mName.endsWith(Apx::File::cInSuffix) || file->mName.endsWith(Apx::File::cOutSuffix) )
    {
       return assignFileAddress(file, PORT_DATA_START, DEFINITION_START, PORT_DATA_BOUNDARY);
    }
-   else if (file->mName.endsWith(".apx") )
+   else if (file->mName.endsWith(Apx::File::cDefinitionSuffix) )
    {
       return assignFileAddress(file, DEFINITION_START, USER_DATA_START, DEFINITION_BOUNDARY);
    }

--- a/apx/src/qapx_node.cpp
+++ b/apx/src/qapx_node.cpp
@@ -62,7 +62,7 @@ namespace Apx
       mPortMap.insert(QString(port->getName()),dynamic_cast<QApxSimplePort*>(port));
    }
 
-   QApxSimplePort *Node::getRequirePortById(int i)
+   QApxSimplePort *Node::getRequirePortById(int i) const
    {
       if (i< mRequirePorts.size())
       {
@@ -71,7 +71,7 @@ namespace Apx
       return (QApxSimplePort*) NULL;
    }
 
-   QApxSimplePort *Node::getProvidePortById(int i)
+   QApxSimplePort *Node::getProvidePortById(int i) const
    {
       if (i< mProvidePorts.size())
       {
@@ -80,7 +80,7 @@ namespace Apx
       return (QApxSimplePort*) NULL;
    }
 
-   QApxSimplePort *Node::findPortByName(const char *name)
+   QApxSimplePort *Node::findPortByName(const char *name) const
    {
       PortMapItertator it = mPortMap.find(QString(name));
       if (it != mPortMap.end())
@@ -95,7 +95,7 @@ namespace Apx
       mName=name;
    }
 
-   QString &Node::getName()
+   const QString &Node::getName() const
    {
       return mName;
    }

--- a/apx/src/qapxdataelement.cpp
+++ b/apx/src/qapxdataelement.cpp
@@ -214,13 +214,14 @@ void QApxDataElementParser::calcLen(QApxDataElement *pElement)
 {
    if (pElement->baseType == QAPX_BASE_TYPE_RECORD)
    {
-      pElement->packLen=0;
+      int packLen=0;
       int end=pElement->pElementList->length();
       for(int i=0;i<end;i++)
       {
          const QApxDataElement *childElement = pElement->pElementList->at(i);
-         pElement->packLen+=childElement->packLen;
+         packLen+=childElement->packLen;
       }
+      pElement->packLen = packLen;
    }
    else
    {

--- a/apx/src/qapxfileparser.cpp
+++ b/apx/src/qapxfileparser.cpp
@@ -26,11 +26,10 @@ Apx::Node* QApxFileParser::parseNode(const char *filepath)
    {
       QTextStream in(&file);
       mApxInStream.open();
-      while(in.atEnd() == false)
+      QString line;
+      while(in.readLineInto(&line))
       {
-         QString line = in.readLine();
-         QByteArray buf(line.toLatin1());
-         mApxInStream.write(buf);
+         mApxInStream.write(line.toLatin1());
       }
       mApxInStream.close();
    }

--- a/apx/src/qapxsimpleport.cpp
+++ b/apx/src/qapxsimpleport.cpp
@@ -1,36 +1,85 @@
 #include "qapxsimpleport.h"
 #include <QByteArray>
+#include <string.h>
+
+static const char attrSeparator = ',';
+static const char attrInitMarker = '=';
+static const char attrInitGroupEndBracket = '}';
+static const char attrInitStringEndMarker = '"';
+
+static const char * buildAttrInitRaw(const char *attr)
+{
+   if (attr==NULL)
+   {
+      return NULL;
+   }
+   char * ret_val = NULL;
+   const char * initStart = strchr(attr, attrInitMarker);
+   const char * initLastChar = NULL;
+   if (NULL != initStart)
+   {
+      // Init value starts on the char after the attrInitMarker
+      initStart = initStart + 1;
+      // Check if signal group
+      initLastChar = strrchr(initStart, attrInitGroupEndBracket);
+      if (NULL == initLastChar)
+      {
+         // Not a group - check if string
+         initLastChar = strrchr(initStart, attrInitStringEndMarker);
+         if (NULL == initLastChar)
+         {
+            // Not a string or group - find init attribute ending if not last attribute
+            initLastChar = strchr(initStart, attrSeparator);
+            if (NULL != initLastChar)
+            {
+               // End is at char before the attrSeparator
+               initLastChar = initLastChar - 1;
+            }
+         }
+      }
+      if (NULL == initLastChar)
+      {
+         // Simple init attribute is last - so duplicate the string
+         ret_val = qstrdup(initStart);
+      }
+      else
+      {
+         const size_t initSize = initLastChar - initStart + 1;
+         ret_val = new char[initSize + 1];
+         memcpy(ret_val, initStart, initSize);
+         ret_val[initSize] ='\0';
+      }
+   }
+   return ret_val;
+}
 
 QApxSimplePort::QApxSimplePort(const char *name, const char *dsg, const char *attr):
-   mName(0),mDsg(0),mAttr(0)
+   mAttrInit(NULL),mPortIndex(-1)
 {
-   if (name != 0)
-   {
-      mName = qstrdup(name);
-   }
-   if (dsg != 0)
-   {
-      mDsg = qstrdup(dsg);
-   }
-   if( attr != 0)
-   {
-      mAttr = qstrdup(attr);
-   }
+   // qstrdup of null pointer will return null (http://doc.qt.io/qt-5/qbytearray.html#qstrdup)
+   mName = qstrdup(name);
+   mDsg = qstrdup(dsg);
+   mAttrFull = qstrdup(attr);
+   mAttrInit = buildAttrInitRaw(attr);
 }
 
 QApxSimplePort::~QApxSimplePort()
 {
-   if (mName != 0)
+   if (mName != NULL)
    {
       delete[] mName;
    }
-   if (mDsg != 0)
+   if (mDsg != NULL)
    {
       delete[] mDsg;
    }
-   if (mAttr != 0)
+   if (mAttrFull != NULL)
    {
-      delete[] mAttr;
+      delete[] mAttrFull;
+   }
+   if (mAttrInit != NULL)
+   {
+      delete[] mAttrInit;
    }
 }
 

--- a/apx/test/test_qapx_client.cpp
+++ b/apx/test/test_qapx_client.cpp
@@ -1,7 +1,6 @@
 #include "test_qapx_client.h"
 #include "qapx_client.h"
 #include <QSignalSpy>
-#include <QDebug>
 #include <QtCore>
 
 void TestApxClient::createClient()
@@ -38,15 +37,22 @@ void TestApxClient::connectToServer()
    QCoreApplication a(argc, 0);
    Apx::Client *client = new Apx::Client(&a);
    QSignalSpy connectedSpy(client, SIGNAL(connected()));
+   QSignalSpy fullyUpdatedSpy(client, SIGNAL(requirePortFullyRefreshed()));
    QSignalSpy disconnectSpy(client, SIGNAL(disconnected()));
    client->createLocalNode(apx_str);
    Apx::NodeData *nodeData = client->getNodeData();
    QVERIFY(nodeData != 0);
+   QCOMPARE(connectedSpy.count(), 0);
+   QCOMPARE(fullyUpdatedSpy.count(), 0);
+   QCOMPARE(disconnectSpy.count(), 0);
    client->connectTcp(QHostAddress::LocalHost, 5000);
    connectedSpy.wait(5000);
    QCOMPARE(connectedSpy.count(), 1);
+   QCOMPARE(fullyUpdatedSpy.count(), 1);
    client->close();
    disconnectSpy.wait(5000);
+   QCOMPARE(connectedSpy.count(), 1);
+   QCOMPARE(fullyUpdatedSpy.count(), 1);
    QCOMPARE(disconnectSpy.count(), 1);
 
 }

--- a/apx/test/test_qapx_file.cpp
+++ b/apx/test/test_qapx_file.cpp
@@ -5,7 +5,19 @@
 void TestApxFile::inputFile()
 {
    Apx::InputFile file("test.in",42);
+   quint8 buf[50];
+   int retval;
    QVERIFY(file.mLength == 42);
+   retval = file.read(buf, 0, 0);
+   QVERIFY(retval == 0);
+   retval = file.read(buf, 41, 1);
+   QVERIFY(retval == 1);
+   retval = file.read(buf, 0, 42);
+   QVERIFY(retval == 42);
+   retval = file.read(buf, 1, 42);
+   QVERIFY(retval == -1);
+   retval = file.read(buf, 0, 43);
+   QVERIFY(retval == -1);
 }
 
 void TestApxFile::outputFile()

--- a/examples/ApxClientTest/simulator.cpp
+++ b/examples/ApxClientTest/simulator.cpp
@@ -10,7 +10,8 @@ SimulatorNode::SimulatorNode(Apx::Client *client, QObject *parent) : QObject(par
 
 }
 
-void SimulatorNode::onRequirePortData(int portId, QString &portName, QVariant &value)
+void SimulatorNode::onRequirePortData(int portId, const QString &portName, const QVariant &value)
+{
 {
    (void) portId;
    if (portName == "TestSignal1")

--- a/examples/ApxClientTest/simulator.h
+++ b/examples/ApxClientTest/simulator.h
@@ -19,7 +19,7 @@ protected:
 signals:
 
 public slots:
-   void onRequirePortData(int portId, QString &portName, QVariant &value);
+   void onRequirePortData(int portId, const QString &portName, const QVariant &value);
 
 };
 

--- a/remotefile/inc/qrmf_base.h
+++ b/remotefile/inc/qrmf_base.h
@@ -5,14 +5,15 @@
 #define RMF_GREETING_START "RMFP/1.0\n"
 #define RMF_NUMHEADER_FORMAT "NumHeader-Format:" //allows values are 16 or 32. This tells other side to expect NumHeader16 or NumHeader32 respectively
 
-#define RMF_CMD_ACK                (quint32) 0   //reserved for future use
-#define RMF_CMD_NACK               (quint32) 1   //reserved for future use
-#define RMF_CMD_EOT                (quint32) 2   //reserved for future use
-#define RMF_CMD_FILE_INFO          (quint32) 3   //serialized file info data structure
-#define RMF_CMD_REVOKE_FILE        (quint32) 4   //used by server to tell clients that the file is no longer available
+#define RMF_DATATYPE_CMD            quint32
+#define RMF_CMD_ACK                (RMF_DATATYPE_CMD) 0   //reserved for future use
+#define RMF_CMD_NACK               (RMF_DATATYPE_CMD) 1   //reserved for future use
+#define RMF_CMD_EOT                (RMF_DATATYPE_CMD) 2   //reserved for future use
+#define RMF_CMD_FILE_INFO          (RMF_DATATYPE_CMD) 3   //serialized file info data structure
+#define RMF_CMD_REVOKE_FILE        (RMF_DATATYPE_CMD) 4   //used by server to tell clients that the file is no longer available
 //range 5-9 reserved for future use
-#define RMF_CMD_FILE_OPEN         (quint32) 10  //opens a file
-#define RMF_CMD_FILE_CLOSE        (quint32) 11  //closes a file
+#define RMF_CMD_FILE_OPEN         (RMF_DATATYPE_CMD) 10  //opens a file
+#define RMF_CMD_FILE_CLOSE        (RMF_DATATYPE_CMD) 11  //closes a file
 
 #define RMF_DIGEST_SIZE          32u //32 bytes is suitable for storing a sha256 hash
 #define RMF_MAXLEN_FILE_NAME     255u

--- a/remotefile/inc/qrmf_filemanager.h
+++ b/remotefile/inc/qrmf_filemanager.h
@@ -2,9 +2,7 @@
 #define QRMF_FILEMANAGER_H
 
 #include <QtGlobal>
-#include <QQueue>
-#include <QSemaphore>
-#include <QThread>
+#include <QObject>
 #include "qrmf_filemap2.h"
 #include "qrmf_msg.h"
 #include "qrmf_base.h"
@@ -12,19 +10,6 @@
 
 namespace RemoteFile
 {
-   class FileManagerWorker : public QThread
-   {
-      Q_OBJECT
-   public:
-      FileManagerWorker();
-
-   protected:
-      RemoteFile::TransmitHandler *mTransmitHandler;
-
-   public slots:
-      void onMessage(RemoteFile::Msg msg);
-   };
-
    class FileManager : public QObject, public RemoteFile::ReceiveHandler
    {
       Q_OBJECT
@@ -41,12 +26,16 @@ namespace RemoteFile
       void processCmd(const char *pBegin, const char *pEnd);
       void processFileWrite(quint32 address, bool more_bit, const char *data, quint32 dataLen);
    protected:
-      FileManagerWorker mWorkerThread;
+      RemoteFile::TransmitHandler *mTransmitHandler;
       RemoteFile::FileMap2 *mLocalFileMap;
       RemoteFile::FileMap2 *mRemoteFileMap;
       QList<RemoteFile::File*> mRequestedFiles;
+
+   private slots:
+      void onMessage(const RemoteFile::Msg& msg);
    signals:
-      void message(RemoteFile::Msg msg);
+      void message(const RemoteFile::Msg& msg);
+      void remoteFileFullWrite(const QString& fileName);
    };
 }
 

--- a/remotefile/inc/qrmf_filemap2.h
+++ b/remotefile/inc/qrmf_filemap2.h
@@ -1,8 +1,8 @@
 /**
   QT adaptation of RemoteFile Layer
 */
-#ifndef QRMF_FILEMAP_H
-#define QRMF_FILEMAP_H
+#ifndef QRMF_FILEMAP2_H
+#define QRMF_FILEMAP2_H
 #include <QString>
 #include <QtGlobal>
 #include <QList>
@@ -51,8 +51,4 @@ protected:
 
 
 }
-#endif // QRMF_FILEMAP_H
-#ifndef QRMF_FILEMAP2_H
-#define QRMF_FILEMAP2_H
-
 #endif // QRMF_FILEMAP2_H

--- a/remotefile/inc/qrmf_proto.h
+++ b/remotefile/inc/qrmf_proto.h
@@ -2,7 +2,6 @@
 #define QRMF_PROTO_H
 
 #include <QtGlobal>
-#include "qrmf_base.h"
 #include "qrmf_file.h"
 
 namespace RemoteFile
@@ -10,7 +9,7 @@ namespace RemoteFile
    int packHeader(char *pDest, int destLimit, quint32 address, bool more_bit=false);
    int unpackHeader(const char *pBegin, const char *pEnd, quint32 *address, bool *more_bit);
 
-   int packFileInfo(char *pDest, int destLimit, RemoteFile::File &file);
+   int packFileInfo(char *pDest, int destLimit, const RemoteFile::File &file);
    int unpackFileInfo(const char *pBegin, const char *pEnd, RemoteFile::File &file, bool networkByteOrder=false);
 
    int packFileOpen(char *pDest, int destLimit, quint32 address);

--- a/remotefile/inc/qrmf_socketadapter.h
+++ b/remotefile/inc/qrmf_socketadapter.h
@@ -40,7 +40,7 @@ class SocketAdapter : public QObject,public RemoteFile::TransmitHandler
 public:
    explicit SocketAdapter(int numHeaderBits=32,QObject *parent = 0);
    virtual ~SocketAdapter();
-   int connectTcp(QHostAddress address,quint16 port);
+   int connectTcp(const QHostAddress& address,quint16 port);
    int connectLocal(const char *filename); //connects to local socket in unix, named pipe on Windows
 #ifdef UNIT_TEST
    int connectMock(MockSocket *socket);

--- a/remotefile/src/qnumheader.cpp
+++ b/remotefile/src/qnumheader.cpp
@@ -53,32 +53,30 @@ int encode16(char *pDest, int destLimit, quint16 value)
  * @param value
  * @return number of bytes read from pBegin. Valid values are 0, 1 and 2. -1 is returned when arguments are invalid (e.g. if value is NULL or pEnd<pBegin)
  */
-int decode16(const char *pBegin, const char *pEnd, quint16 *value)
+int decode16(const char* const pBegin, const char* const pEnd, quint16 *value)
 {
    int retval = 0; //default is to read 0 bytes starting from pBegin
-   const char *pNext=pBegin;
    if( (pBegin != 0) && (pBegin<pEnd) && (value != NULL) )
    {
-      char c = *pNext++;
+      const uchar c = *(const uchar* const)pBegin;
       if(c & 0x80u) //is long_bit set?
       {
-         if(pNext<pEnd)
+         if(pBegin+sizeof(quint16)<=pEnd)
          {
             retval = (int) sizeof(quint16);
-            quint16 tmp = qFromBigEndian<quint16>((const uchar*) pBegin);
+            quint16 tmp = qFromBigEndian<quint16>(pBegin);
             tmp&=(quint16)0x7FFFu; //clear the long bit
             if(tmp<128u)
             {
                tmp+=32768u; //interpret range 0-127 as range 32768-32895 when long_bit was set to 1
             }
             *value=tmp;
-            pNext++;
          }
       }
       else
       {
          retval = (int) sizeof(quint8);
-         *value=(quint8) c;
+         *value=(const quint8) c;
       }
    }
    else
@@ -118,28 +116,26 @@ int encode32(char *pDest, int destLimit, quint32 value)
    return retval;
 }
 
-int decode32(const char *pBegin, const char *pEnd, quint32 *value)
+int decode32(const char* const pBegin, const char* const pEnd, quint32 *value)
 {
    int retval = 0; //default is to read 0 bytes starting from pBegin
-   const char *pNext=pBegin;
    if( (pBegin != 0) && (pBegin<pEnd) && (value != NULL) )
    {
-      char c = *pNext++;
+      const uchar c = *(const uchar* const)pBegin;
       if(c & 0x80u) //is long_bit set?
       {
-         if(pNext+2<pEnd)
+         if(pBegin+sizeof(quint32)<=pEnd)
          {
             retval = (int) sizeof(quint32);
-            quint32 tmp = qFromBigEndian<quint32>((const uchar*) pBegin);
+            quint32 tmp = qFromBigEndian<quint32>(pBegin);
             tmp&=(quint32)0x7FFFFFFFu; //clear the long bit
             *value=tmp;
-            pNext++;
          }
       }
       else
       {
          retval = (int) sizeof(quint8);
-         *value=(quint8) c;
+         *value=(const quint8) c;
       }
    }
    else

--- a/remotefile/src/qrmf_filemap2.cpp
+++ b/remotefile/src/qrmf_filemap2.cpp
@@ -84,7 +84,8 @@ bool FileMap2::assignFileAddress(RemoteFile::File *file, quint32 startAddress, q
       //insert after a
       if ( (startAddress & (startAddress-1))==0 && ((addressBoundary & (addressBoundary-1))==0) )
       {
-         quint32 prevEndAddress = mFiles[a]->mAddress+mFiles[a]->mLength;
+         const RemoteFile::File* const& currFile = mFiles.at(a);
+         quint32 prevEndAddress = currFile->mAddress+currFile->mLength;
          file->mAddress = (prevEndAddress + (addressBoundary-1)) & (~(addressBoundary-1));
       }
       else
@@ -100,7 +101,7 @@ bool FileMap2::assignFileAddress(RemoteFile::File *file, quint32 startAddress, q
    }
    if ( b != -1)
    {
-      endAddress=mFiles[b]->mAddress;
+      endAddress=mFiles.at(b)->mAddress;
    }
    return verifyFileAddress(file, startAddress, endAddress);
 }
@@ -125,7 +126,8 @@ File *FileMap2::findByAddress(quint32 address)
 {
    if (mLastFileIndex>=0)
    {
-      if ( (mFiles[mLastFileIndex]->mAddress<=address) && (address < mFiles[mLastFileIndex]->mAddress + mFiles[mLastFileIndex]->mLength ) )
+      const RemoteFile::File* const& lastFile = mFiles.at(mLastFileIndex);
+      if ( (lastFile->mAddress<=address) && (address < lastFile->mAddress + lastFile->mLength ) )
       {
          return mFiles[mLastFileIndex];
       }
@@ -136,7 +138,8 @@ File *FileMap2::findByAddress(quint32 address)
 
    for (i=0;i<numItems;i++)
    {
-      if ( (mFiles[i]->mAddress<=address) && (address < mFiles[i]->mAddress + mFiles[i]->mLength ) )
+      const RemoteFile::File* const& currFile = mFiles.at(i);
+      if ( (currFile->mAddress<=address) && (address < currFile->mAddress + currFile->mLength ) )
       {
          mLastFileIndex=i;
          return mFiles[i];

--- a/remotefile/test/test_qrmf_proto.cpp
+++ b/remotefile/test/test_qrmf_proto.cpp
@@ -134,7 +134,7 @@ void TestRemoteFileProtocol::test_packFileInfo()
    int result;
 
    result = RemoteFile::packFileInfo(array.data(), array.length(), file1);
-   QCOMPARE(result, RMF_FILEINFO_BASE_LEN+(int)strlen(name1)+1);
+   QCOMPARE(result, (int)RMF_FILEINFO_BASE_LEN+(int)strlen(name1)+1);
 
    QByteArray expected = QByteArray("\x03\x00\x00\x00\x78\x56\x34\x12\xe8\x03\x00\x00\x00\x00\x00\x00" //16
                                     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" //32
@@ -155,7 +155,7 @@ void TestRemoteFileProtocol::test_unpackFileInfo()
                                     ,RMF_FILEINFO_BASE_LEN+(int)strlen(name1)+1);
    RemoteFile::File file1;
    int result = RemoteFile::unpackFileInfo(array.constData(), array.constData()+array.length(), file1);
-   QCOMPARE(result, RMF_FILEINFO_BASE_LEN+(int)strlen(name1)+1);
+   QCOMPARE(result, (int)RMF_FILEINFO_BASE_LEN+(int)strlen(name1)+1);
    QCOMPARE(file1.mName, QString("file1.txt"));
    QCOMPARE(file1.mAddress, (quint32) 0x12345678);
    QCOMPARE(file1.mLength, (quint32) 1000);
@@ -164,7 +164,7 @@ void TestRemoteFileProtocol::test_unpackFileInfo()
 
    //it should also work if null-terminator is forgotten
    result = RemoteFile::unpackFileInfo(array.constData(), array.constData()+array.length()-1, file1);
-   QCOMPARE(result, RMF_FILEINFO_BASE_LEN+(int)strlen(name1));
+   QCOMPARE(result, (int)RMF_FILEINFO_BASE_LEN+(int)strlen(name1));
    QCOMPARE(file1.mName, QString("file1.txt"));
    QCOMPARE(file1.mAddress, (quint32) 0x12345678);
    QCOMPARE(file1.mLength, (quint32) 1000);
@@ -173,7 +173,7 @@ void TestRemoteFileProtocol::test_unpackFileInfo()
 
    //what if array cuts of directly after RMF_FILEINFO_BASE_LEN bytes?
    result = RemoteFile::unpackFileInfo(array.constData(), array.constData()+RMF_FILEINFO_BASE_LEN, file1);
-   QCOMPARE(result, RMF_FILEINFO_BASE_LEN);
+   QCOMPARE(result, (int)RMF_FILEINFO_BASE_LEN);
    QCOMPARE(file1.mName, QString(""));
    QCOMPARE(file1.mAddress, (quint32) 0x12345678);
    QCOMPARE(file1.mLength, (quint32) 1000);
@@ -186,7 +186,7 @@ void TestRemoteFileProtocol::test_unpackFileInfo()
                          "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" //48
                          "\x00",RMF_FILEINFO_BASE_LEN+1); //49
    result = RemoteFile::unpackFileInfo(array.constData(), array.constData()+array.length(), file1);
-   QCOMPARE(result, RMF_FILEINFO_BASE_LEN+1);
+   QCOMPARE(result, (int)RMF_FILEINFO_BASE_LEN+1);
    QCOMPARE(file1.mName, QString(""));
    QCOMPARE(file1.mAddress, (quint32) 0x12345678);
    QCOMPARE(file1.mLength, (quint32) 1000);
@@ -230,12 +230,12 @@ void TestRemoteFileProtocol::test_unpackFileOpen()
       QCOMPARE(result, 0);
    }
    result = RemoteFile::unpackFileOpen(array.constData(),array.constData()+array.length(),address);
-   QCOMPARE(result, RMF_FILE_OPEN_LEN);
+   QCOMPARE(result, (int)RMF_FILE_OPEN_LEN);
    QCOMPARE(address, (quint32)0x00000000);
 
    array = QByteArray(  "\x0a\x00\x00\x00\x78\x56\x34\x12",RMF_FILE_OPEN_LEN);
    result = RemoteFile::unpackFileOpen(array.constData(),array.constData()+array.length(),address);
-   QCOMPARE(result, RMF_FILE_OPEN_LEN);
+   QCOMPARE(result, (int)RMF_FILE_OPEN_LEN);
    QCOMPARE(address, (quint32)0x12345678);
 
    //verify invalid cmdType check
@@ -279,12 +279,12 @@ void TestRemoteFileProtocol::test_unpackFileClose()
       QCOMPARE(result, 0);
    }
    result = RemoteFile::unpackFileClose(array.constData(),array.constData()+array.length(),address);
-   QCOMPARE(result, RMF_FILE_CLOSE_LEN);
+   QCOMPARE(result, (int)RMF_FILE_CLOSE_LEN);
    QCOMPARE(address, (quint32)0x00000000);
 
    array = QByteArray(  "\x0b\x00\x00\x00\x78\x56\x34\x12",RMF_FILE_CLOSE_LEN);
    result = RemoteFile::unpackFileClose(array.constData(),array.constData()+array.length(),address);
-   QCOMPARE(result, RMF_FILE_CLOSE_LEN);
+   QCOMPARE(result, (int)RMF_FILE_CLOSE_LEN);
    QCOMPARE(address, (quint32)0x12345678);
 
    //verify invalid cmdType check

--- a/remotefile/test/test_qrmf_proto.h
+++ b/remotefile/test/test_qrmf_proto.h
@@ -3,15 +3,6 @@
 
 #include <QtTest/QtTest>
 
-#define RMF_CMD_ACK                (quint32) 0   //reserved for future use
-#define RMF_CMD_NACK               (quint32) 1   //reserved for future use
-#define RMF_CMD_EOT                (quint32) 2   //reserved for future use
-#define RMF_CMD_FILE_INFO          (quint32) 3   //serialized file info data structure
-#define RMF_CMD_REVOKE_FILE        (quint32) 4   //used by server to tell clients that the file is no longer available
-//range reserved for future use
-#define RMF_CMD_FILE_OPEN         (quint32) 10  //opens a file
-#define RMF_CMD_FILE_CLOSE        (quint32) 11  //closes a file
-
 class TestRemoteFileProtocol : public QObject
 {
    Q_OBJECT


### PR DESCRIPTION
Feature extensions:
* method to get raw version of the port init value
* Add a signal that notifies when complete write occurs in one sweep (such as when apx server connect is completed)

Debug enhancements:
* Add debug messages if write fails
* add apx file testcase
* and improve socket state debugging
* Update the unittest for remotefile so that it is possible to execute

Corrections:
* fix issue for large apxProvidePortConnect and add a todo for another potential issue in apxDataMsg
* Remove the FileManagerWorker since only limited work was offloaded to it and it resulted in issues with multiple threads accessing the same socket. Should consider offloading all encoding+decoding to separate thread later.
* add return value check of socket write
* fix issue where decode32 with longbit but insufficient data was interpreted as a parse error
* manage data that may arrive while we are processing previous data (not sure if Qt would signal if data is added wile processin readyread() - anyway this reduces latency)

Optimizations:
* Optimizations removing magic numbers and reducing use of temporary pointers
* optimize data/memory allocation
* make it possible to desire in data notifications using id only
* Send signals with const ref (Warning: breaks backwards compatablity for previous signal+slot connections)
* optimize datastructure lookup
* const and other optimization updates aiding the compiler
* optimize processing of require signals

Cleanup:
* qstring cleanup
* Refactor assert to not cause gcc compiler warning in production build where Q_ASSERTS are removed
* use unique define for APX unit tests to avoid issue with rmf mock socket
* add Q_ASSERT of issue that can not occur in runtime
* remove unused RMF_CMD_* redefinitions and includes
* include cleanup
* remove unused define
* correct include guard and compiler warning