### PR TITLE
add sanity check to the message size reported in header

### DIFF
--- a/remotefile/inc/qrmf_socketadapter.h
+++ b/remotefile/inc/qrmf_socketadapter.h
@@ -29,7 +29,7 @@
 #define RMF_ERR_INVALID_PARSE          4u
 #define RMF_ERR_BAD_MSG                5u
 #define RMF_ERR_BAD_ALLOC              6u
-
+#define RMF_ERR_MSG_LEN_TOO_LONG       7u
 
 namespace RemoteFile
 {

--- a/remotefile/test/test_qrmf_socketadapter.h
+++ b/remotefile/test/test_qrmf_socketadapter.h
@@ -17,6 +17,8 @@ private slots:
    void test_getSocketReadAvail_multi();
    void test_getSocketReadAvail_not_connected();
    void test_bad_message();
+   void test_multiple_bad_messages();
+   void test_long_message();
 };
 
 }


### PR DESCRIPTION
configure receive buffer size for TCP socket as well
break data parsing on error
highlight debug build in constructor
add debug possibility if corrupt data is received on socket